### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,5 @@ igraph
 python-louvain==0.15
 rpy2==3.4.2
 scanpy==1.8.2
+scipy==1.10.1
 scikit-learn==1.0.2


### PR DESCRIPTION
Added scipy==1.10.1 , as triu is deprecated since SciPy 1.11 and has been removed in SciPy 1.13 .

https://stackoverflow.com/questions/78279136/importerror-cannot-import-name-triu-from-scipy-linalg-gensim